### PR TITLE
NL-101 added ability to rotate certain platforms

### DIFF
--- a/global.gd
+++ b/global.gd
@@ -51,6 +51,8 @@ var gender: String = "male":
 var double_jump = false
 var wall_jump = false
 var last_location = 0
+var rotate = 0
+var selected_platform = "not_rotatable"
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:

--- a/global.gd
+++ b/global.gd
@@ -52,7 +52,7 @@ var double_jump = false
 var wall_jump = false
 var last_location = 0
 var rotate = 0
-var selected_platform = "not_rotatable"
+var rotatable_platform = false
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:

--- a/level/platforms/default_platform.gd
+++ b/level/platforms/default_platform.gd
@@ -9,7 +9,7 @@ func reload():
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	Global.selected_platform = "not_rotatable"
+	Global.rotatable_platform = false
 	pass # Replace with function body.
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.

--- a/level/platforms/default_platform.gd
+++ b/level/platforms/default_platform.gd
@@ -9,6 +9,7 @@ func reload():
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
+	Global.selected_platform = "not_rotatable"
 	pass # Replace with function body.
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.

--- a/level/platforms/trampoline_platform.gd
+++ b/level/platforms/trampoline_platform.gd
@@ -3,14 +3,13 @@ extends StaticBody2D
 @onready var player = get_tree().current_scene.get_node("Player") as Player
 @onready var platform_gun = get_tree().current_scene.get_node("Player/Sprite2D/PlatformGun")
 var timer = 0
-
 func reload():
 	platform_gun.can_shoot = 1
 	queue_free()
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	pass # Replace with function body.
+	rotation_degrees = Global.rotate
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:
@@ -19,7 +18,7 @@ func _process(delta: float) -> void:
 	else:
 		$Sprite2D.visible = true
 		$onSprite.visible = false
-	
+
 	if Input.is_action_just_pressed("reload") or player.current_health <= 0:
 			reload()
 
@@ -29,7 +28,7 @@ func _mouse_enter():
 func _mouse_exit():
 	platform_gun.can_shoot = 1
 
-func _on_area_2d_body_entered(body: Node2D) -> void:
+func _on_area_2d_body_entered(_body: Node2D) -> void:
 	$Sprite2D.visible = false
 	$onSprite.visible = true
 	player.velocity.y += 0.8*player.JUMP_VELOCITY*cos(deg_to_rad(rotation_degrees))

--- a/level/platforms/velocity_platform.gd
+++ b/level/platforms/velocity_platform.gd
@@ -8,7 +8,7 @@ func reload():
 	queue_free()
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	pass # Replace with function body.
+	rotation_degrees = Global.rotate
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta: float) -> void:
@@ -21,6 +21,6 @@ func _mouse_enter():
 func _mouse_exit():
 	platform_gun.can_shoot = 1
 
-func _on_area_2d_body_entered(_body) -> void:
+func _on_area_2d_body_entered(_body: Player) -> void:
 	AudioManager.play_sfx("velocity_boost")
 	player.boost()

--- a/player/platform_gun.gd
+++ b/player/platform_gun.gd
@@ -43,10 +43,25 @@ func _process(_delta: float) -> void:
 
 	if Input.is_action_just_pressed("platform_1"):
 		selected_platform = Global.p_1
+		Global.rotate = 0
 	if Input.is_action_just_pressed("platform_2"):
 		selected_platform = Global.p_2
+		Global.rotate = 0
 	if Input.is_action_just_pressed("platform_3"):
 		selected_platform = Global.p_3
+		Global.rotate = 0
+	
+	if Input.is_action_just_pressed("rotate"):
+		Global.rotate += 90
+		if Global.rotate == 360:
+			Global.rotate = 0
+	
+	if selected_platform.resource_path == "res://level/platforms/trampoline_platform.tscn" or \
+	selected_platform.resource_path == "res://level/platforms/velocity_platform.tscn":
+		#print(selected_platform.resource_path)
+		Global.selected_platform = "rotatable"
+	else:
+		Global.selected_platform = "not_rotatable"
 	
 	if game_manager:
 		platform_preview.handle_drawing(tiles, platform_count, can_shoot, can_shoot_player, game_manager.is_game_paused)

--- a/player/platform_gun.gd
+++ b/player/platform_gun.gd
@@ -59,9 +59,9 @@ func _process(_delta: float) -> void:
 	if selected_platform.resource_path == "res://level/platforms/trampoline_platform.tscn" or \
 	selected_platform.resource_path == "res://level/platforms/velocity_platform.tscn":
 		#print(selected_platform.resource_path)
-		Global.selected_platform = "rotatable"
+		Global.rotatable_platform = true
 	else:
-		Global.selected_platform = "not_rotatable"
+		Global.rotatable_platform = false
 	
 	if game_manager:
 		platform_preview.handle_drawing(tiles, platform_count, can_shoot, can_shoot_player, game_manager.is_game_paused)

--- a/player/platform_preview.gd
+++ b/player/platform_preview.gd
@@ -8,7 +8,7 @@ func attach_preview(platform: PackedScene) -> void:
 	# Instantiate a new preview sprite from the platform scene
 	var instance = platform.instantiate()
 	var sprite = instance.get_node("Sprite2D") as Sprite2D
-	sprite.rotation_degrees = instance.rotation_degrees
+	#sprite.rotation_degrees = instance.rotation_degrees#+Global.rotate
 	instance.remove_child(sprite) # Detach from the full platform instance
 
 	sprite.modulate = Color(0.8, 0.8, 0.8, 0.5) # Gray + transparent
@@ -27,6 +27,8 @@ func handle_drawing(tiles: TileMapLayer, platform_count:int, can_shoot: bool, ca
 		var preview:Sprite2D = get_child(0)
 		var global_scaled = tiles.get_global_mouse_position()
 		var node_coord = tiles.local_to_map(tiles.to_local(global_scaled))
+		if(Global.selected_platform == "rotatable"):
+			preview.rotation_degrees = Global.rotate
 		if platform_count > 0 and can_shoot and can_shoot_player == 1 and \
 			tiles.get_cell_source_id(node_coord) == -1 and !is_game_paused:
 				preview.modulate = Color(0.5, 0.5, 0.5, 0.8)

--- a/player/platform_preview.gd
+++ b/player/platform_preview.gd
@@ -27,7 +27,7 @@ func handle_drawing(tiles: TileMapLayer, platform_count:int, can_shoot: bool, ca
 		var preview:Sprite2D = get_child(0)
 		var global_scaled = tiles.get_global_mouse_position()
 		var node_coord = tiles.local_to_map(tiles.to_local(global_scaled))
-		if(Global.selected_platform == "rotatable"):
+		if Global.rotatable_platform == true:
 			preview.rotation_degrees = Global.rotate
 		if platform_count > 0 and can_shoot and can_shoot_player == 1 and \
 			tiles.get_cell_source_id(node_coord) == -1 and !is_game_paused:

--- a/player/player.gd
+++ b/player/player.gd
@@ -9,7 +9,7 @@ const ACCELERATION_SPEED = WALK_SPEED * 6.0
 const TERMINAL_VELOCITY = 700
 const WALL_JUMP_FACTOR = 150
 const MAX_BOOST_Y = 1000
-const MAX_BOOST_X = 500
+const MAX_BOOST_X = 1000
 
 var gravity: int = ProjectSettings.get("physics/2d/default_gravity")
 @onready var platform_detector := $PlatformDetector as RayCast2D
@@ -45,13 +45,13 @@ func _physics_process(delta: float) -> void:
 		velocity.y *= 0.6
 	# Fall.
 	velocity.y = minf(TERMINAL_VELOCITY, velocity.y + gravity * delta)
-
+	
 	var direction := Input.get_axis("move_left", "move_right") * WALK_SPEED
 	velocity.x = move_toward(velocity.x, direction, ACCELERATION_SPEED * delta)
+
 	
 	if Input.is_action_just_pressed("reload"):
 		position = Global.last_location
-	
 	if not is_zero_approx(velocity.x):
 		if velocity.x > 0.0:
 			sprite.scale.x = 0.35
@@ -127,7 +127,10 @@ func try_jump() -> void:
 	
 func boost():
 	velocity.x = min(velocity.x* 4, MAX_BOOST_X)
+	if velocity.x < 0:
+		velocity.x = maxf(velocity.x* 4, -1*MAX_BOOST_X)
 	velocity.y = min(velocity.y* 1.5, MAX_BOOST_Y)
+	
 
 func mouse_entered():
 	PlatformGun.can_shoot = 0

--- a/project.godot
+++ b/project.godot
@@ -119,6 +119,11 @@ platform_3={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":51,"key_label":0,"unicode":51,"location":0,"echo":false,"script":null)
 ]
 }
+rotate={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":81,"key_label":0,"unicode":113,"location":0,"echo":false,"script":null)
+]
+}
 
 [layer_names]
 


### PR DESCRIPTION
Added ability to rotate trampoline and velocity platforms

Rotate with "q" key, can preview rotation with "M2" key

selected_platform in Global script checks if the selected platform should be rotate-able. 
rotate in global script holds the rotation amount.